### PR TITLE
Design: UsMenu UI 수정, UsMain UI 수정, CommonFooter max-width 380px으로 수정

### DIFF
--- a/src/components/common/CommonFooter.styled.ts
+++ b/src/components/common/CommonFooter.styled.ts
@@ -5,7 +5,7 @@ export const Container = styled.section`
   position: fixed;
   bottom: 20px;
   width: 88%;
-  max-width: 440px;
+  max-width: 380px;
   height: 72px;
   background-color: ${({ theme }) => theme.colors.gray1};
   stroke-width: 1.4px;

--- a/src/components/us/menu/UsMenu.tsx
+++ b/src/components/us/menu/UsMenu.tsx
@@ -20,33 +20,45 @@ const UsMenu = forwardRef<HTMLDivElement, UsMenuProps>(
         <S.Back src={back} onClick={onClose} />
         <S.MenuSectionBox>
           <S.MenuSection>
-            <S.Img src={edit} />
-            <S.Text>회원정보 수정</S.Text>
+            <S.MenuHover>
+              <S.Img src={edit} />
+              <S.Text>회원정보 수정</S.Text>
+            </S.MenuHover>
           </S.MenuSection>
           <S.Line />
           <S.MenuSection>
-            <S.Img src={theme} />
-            <S.Text>어스 테마 바꾸기</S.Text>
+            <S.MenuHover>
+              <S.Img src={theme} />
+              <S.Text>어스 테마 바꾸기</S.Text>
+            </S.MenuHover>
           </S.MenuSection>
           <S.Line />
           <S.MenuSection>
-            <S.Img src={shopping} />
-            <S.Text>구매목록</S.Text>
+            <S.MenuHover>
+              <S.Img src={shopping} />
+              <S.Text>구매목록</S.Text>
+            </S.MenuHover>
           </S.MenuSection>
           <S.Line />
           <S.MenuSection>
-            <S.Img src={send} />
-            <S.Text>문의하기</S.Text>
+            <S.MenuHover>
+              <S.Img src={send} />
+              <S.Text>문의하기</S.Text>
+            </S.MenuHover>
           </S.MenuSection>
           <S.Line />
           <S.MenuSection>
-            <S.Img src={logout} />
-            <S.Text>로그아웃</S.Text>
+            <S.MenuHover>
+              <S.Img src={logout} />
+              <S.Text>로그아웃</S.Text>
+            </S.MenuHover>
           </S.MenuSection>
           <S.Line />
           <S.MenuSection>
-            <S.Img src={quit} />
-            <S.Text>탈퇴</S.Text>
+            <S.MenuHover>
+              <S.Img src={quit} />
+              <S.Text>탈퇴</S.Text>
+            </S.MenuHover>
           </S.MenuSection>
         </S.MenuSectionBox>
       </S.MenuContainer>

--- a/src/components/us/menu/styled.ts
+++ b/src/components/us/menu/styled.ts
@@ -1,10 +1,10 @@
 import styled from "styled-components";
 
 export const MenuContainer = styled.div<{ $isOpen: boolean }>`
-  position: absolute; /* fixed → absolute 유지 */
+  position: absolute;
   padding-top: 20px;
   top: 0;
-  left: 0;
+  left: 0px;
   width: 234px;
   height: 100%;
   background: white;
@@ -19,7 +19,7 @@ export const MenuContainer = styled.div<{ $isOpen: boolean }>`
 export const Back = styled.img`
   cursor: pointer;
   position: absolute;
-  right: 40px;
+  right: 45px;
 `;
 
 export const MenuSectionBox = styled.div`
@@ -41,8 +41,8 @@ export const MenuSection = styled.div`
 `;
 
 export const Img = styled.img`
-  width: 24px;
-  height: 24px;
+  width: 20px;
+  height: 20px;
 `;
 
 export const Text = styled.span`
@@ -53,6 +53,26 @@ export const Text = styled.span`
   font-weight: 400;
   line-height: normal;
   letter-spacing: -0.64px;
+`;
+
+export const MenuHover = styled.div`
+  display: flex;
+  height: 40px;
+  padding: 8px 16px;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+  &:hover {
+    border-radius: 24px;
+    background: ${({ theme }) => theme.colors.white};
+    box-shadow: 0px 0px 10px 0px rgba(0, 0, 0, 0.14);
+    color: ${({ theme }) => theme.colors.gray5};
+
+    ${Text} {
+      font-weight: 700;
+    }
+  }
 `;
 
 export const Line = styled.div`

--- a/src/components/us/styled.ts
+++ b/src/components/us/styled.ts
@@ -41,7 +41,7 @@ export const MyRanking = styled.div`
 `;
 
 export const RankingText = styled.div`
-  color: var(--Gray5, #2e302d);
+  color: ${({ theme }) => theme.colors.gray5};
   text-align: center;
   font-family: Pretendard;
   font-size: 16px;
@@ -52,7 +52,9 @@ export const RankingText = styled.div`
 `;
 
 /* UsMain.tsx ------- */
-export const StepContainer = styled.div``;
+export const StepContainer = styled.div`
+  margin-top: -25px;
+`;
 export const StepImage = styled.img`
   position: relative;
   margin: 0 auto;
@@ -245,8 +247,8 @@ export const MarketList = styled.div`
   margin-top: 10px;
 `;
 export const MarketItem = styled.div`
-  width: 80px;
-  height: 80px;
+  width: 75px;
+  height: 75px;
   flex-shrink: 0;
   border-radius: 24px;
   border: 1px solid ${({ theme }) => theme.colors.gray2};


### PR DESCRIPTION
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성-->

## 📸 Screenshot
<img width="1392" alt="스크린샷 2025-04-04 13 32 07" src="https://github.com/user-attachments/assets/d4c1612e-2a99-4ebb-a1a1-f1241cdaeaf8" />

<!-- 작업한 화면의 스크린 샷 -->

## 📍 PR Point
- menuUI 수정

> - 문제발생: styled.ts에서 MenuHover 컴포넌트에서 Text 스타일이 적용되지 않는 문제는 styled-components의 순서 관련 이슈 때문이었음.
> - 원인: 코드에서 MenuHover 스타일 컴포넌트가 Text 컴포넌트보다 먼저 정의되어 있음.
> - TypeScript는 코드를 순차적으로 실행하므로, MenuHover가 정의될 때 아직 Text 컴포넌트가 무엇인지 알지 못함. 
> - 해결방법: 순서 변경 (Text 컴포넌트를 MenuHover 컴포넌트보다 먼저 정의함)

<!-- 자랑하고 싶은 부분!  -->

## 📢 Notices
CommonFooter max-width: 440px -> 380px 으로 수정
<!--공용으로 사용하는(Extension) 부분에 대한 설명-->

## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- ex) #12
